### PR TITLE
DE23830 - Browserify '-s' doesn't work properly when requireJS is on the page

### DIFF
--- a/node-siren-parser.js
+++ b/node-siren-parser.js
@@ -1,3 +1,11 @@
 'use strict';
 
-module.exports = require('siren-parser');
+if (!window.D2L) {
+	window.D2L = {};
+}
+
+if (!window.D2L.Siren) {
+	window.D2L.Siren = {};
+}
+
+window.D2L.Siren.Parse = require('siren-parser');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "d2l-siren-parser",
   "scripts": {
     "postinstall": "bower install",
-    "build": "browserify node-siren-parser.js -s D2L.Siren.Parse -o siren-parser.js",
+    "build": "browserify node-siren-parser.js -o siren-parser.js",
     "serve": "polyserve -p 8081",
     "test:lint:js": "eslint test/ --ext .js",
     "test:lint:html": "eslint *.html",

--- a/siren-parser.js
+++ b/siren-parser.js
@@ -1,7 +1,15 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g=(g.D2L||(g.D2L = {}));g=(g.Siren||(g.Siren = {}));g.Parse = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
-module.exports = require('siren-parser');
+if (!window.D2L) {
+	window.D2L = {};
+}
+
+if (!window.D2L.Siren) {
+	window.D2L.Siren = {};
+}
+
+window.D2L.Siren.Parse = require('siren-parser');
 
 },{"siren-parser":3}],2:[function(require,module,exports){
 'use strict';
@@ -600,5 +608,4 @@ module.exports = {
 	getMatchingValue: getMatchingValue
 };
 
-},{}]},{},[1])(1)
-});
+},{}]},{},[1]);


### PR DESCRIPTION
https://rally1.rallydev.com/#/15545167705/detail/defect/86613973692?fdp=true

Nitro (and some other things like awards and some IFRAs) use requireJS

The issue is that requireJS sets the global `define` property (and sets `define.amd`), and `browserify -s` wants to respect this over your entered namespace parameter for some reason.

The issue is in this bit of minified code generated by `browserify -s`:
```
else if(typeof define==="function"&&define.amd){define([],f)}
```

To get around it, instead of using `browserify -s`, I just do the namespacing myself